### PR TITLE
Fix #5: Implement mock student endpoint

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -7,6 +7,7 @@ dotenv.config();
 const envSchema = z.object({
   PORT: z.string().default('3000').transform((val) => parseInt(val, 10)),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+  DATA_SOURCE: z.enum(['mock', 'postgres']).default('mock'),
 });
 
 const parseEnv = () => {

--- a/src/controllers/student.controller.ts
+++ b/src/controllers/student.controller.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+import { StudentRepositoryFactory } from '../factories/student.repository.factory';
+
+export const getStudents = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const repository = StudentRepositoryFactory.getRepository();
+    const students = await repository.getAll();
+    res.status(200).json(students);
+  } catch (error) {
+    console.error('Error fetching students:', error);
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+};

--- a/src/data/students.json
+++ b/src/data/students.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "name": "John Doe", "email": "john@example.com" },
+  { "id": 2, "name": "Jane Smith", "email": "jane@example.com" }
+]

--- a/src/factories/student.repository.factory.ts
+++ b/src/factories/student.repository.factory.ts
@@ -1,0 +1,17 @@
+import { config } from '../config/env';
+import { IStudentRepository } from '../repositories/student.repository.interface';
+import { MockStudentRepository } from '../repositories/mock.student.repository';
+
+export class StudentRepositoryFactory {
+  static getRepository(): IStudentRepository {
+    switch (config.DATA_SOURCE) {
+      case 'mock':
+        return new MockStudentRepository();
+      // Future implementations:
+      // case 'postgres':
+      //   return new PostgresStudentRepository();
+      default:
+        throw new Error(`Unsupported data source: ${config.DATA_SOURCE}`);
+    }
+  }
+}

--- a/src/repositories/mock.student.repository.ts
+++ b/src/repositories/mock.student.repository.ts
@@ -1,0 +1,18 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+import { IStudentRepository } from './student.repository.interface';
+import { Student } from '../types/student';
+
+export class MockStudentRepository implements IStudentRepository {
+  private readonly dataPath = path.join(process.cwd(), 'src/data/students.json');
+
+  async getAll(): Promise<Student[]> {
+    try {
+      const data = await readFile(this.dataPath, 'utf-8');
+      return JSON.parse(data) as Student[];
+    } catch (error) {
+      console.error('Error reading mock data:', error);
+      return [];
+    }
+  }
+}

--- a/src/repositories/student.repository.interface.ts
+++ b/src/repositories/student.repository.interface.ts
@@ -1,0 +1,5 @@
+import { Student } from '../types/student';
+
+export interface IStudentRepository {
+  getAll(): Promise<Student[]>;
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,8 +1,10 @@
 import { Router } from 'express';
 import { getHealth } from '../controllers/health.controller';
+import studentRoutes from './student.routes';
 
 const router = Router();
 
 router.get('/health', getHealth);
+router.use('/students', studentRoutes);
 
 export default router;

--- a/src/routes/student.routes.ts
+++ b/src/routes/student.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getStudents } from '../controllers/student.controller';
+
+const router = Router();
+
+router.get('/', getStudents);
+
+export default router;

--- a/src/types/student.ts
+++ b/src/types/student.ts
@@ -1,0 +1,5 @@
+export interface Student {
+  id: number;
+  name: string;
+  email: string;
+}


### PR DESCRIPTION
Summary of changes made:
- Implemented `/students` endpoint serving mock data from JSON.
- Implemented Dependency Inversion and Factory patterns to allow for future database integration.
- Added `DATA_SOURCE` configuration to select between 'mock' and other implementations (defaulting to 'mock').

Closes #5

List of files modified:
- `src/config/env.ts` (Modified)
- `src/types/student.ts` (Created)
- `src/repositories/student.repository.interface.ts` (Created)
- `src/data/students.json` (Created)
- `src/repositories/mock.student.repository.ts` (Created)
- `src/factories/student.repository.factory.ts` (Created)
- `src/controllers/student.controller.ts` (Created)
- `src/routes/student.routes.ts` (Created)
- `src/routes/index.ts` (Modified)

Testing notes:
- Ensure `DATA_SOURCE` environment variable is set to 'mock' (or unset, as it defaults to 'mock').
- Send a GET request to `/students` (or `/api/v1/students` depending on the global prefix) to receive the list of students.