### PR TITLE
Fix #7: Refactor project as Backstage template

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Template
+metadata:
+  name: standard-service-template
+  title: Standard Service Template
+  description: A template to scaffold new services.
+spec:
+  type: service
+  owner: platform-engineering

--- a/skeleton/README.md
+++ b/skeleton/README.md
@@ -1,0 +1,44 @@
+# Node API Example
+
+This is a professional Node.js API boilerplate built with TypeScript, Express, and Clean Architecture principles.
+
+## Features
+
+- **TypeScript**: Strict type safety.
+- **Express**: Fast, unopinionated web framework.
+- **Clean Architecture**: Separation of concerns (Controllers, Routes, Utils).
+- **Validation**: Zod for environment and request validation.
+- **Logging**: Winston logger.
+- **Security**: Helmet & CORS.
+- **Standard Tooling**: ESLint, Prettier, Nodemon.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js v18+
+- npm
+
+### Installation
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Set up environment:
+   ```bash
+   cp .env.example .env
+   # Update .env variables if needed
+   ```
+
+### Scripts
+
+- `npm run dev`: Start development server.
+- `npm run build`: Build for production.
+- `npm start`: Start production server.
+- `npm run lint`: Run linting.
+
+## API Endpoints
+
+- `GET /api/v1/health`: Health check.

--- a/skeleton/catalog-info.yaml
+++ b/skeleton/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.name }}
+  description: ${{ values.description }}
+spec:
+  type: service
+  lifecycle: experimental
+  owner: ${{ values.owner }}

--- a/skeleton/package.json
+++ b/skeleton/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "${{ values.name }}",
+  "version": "1.0.0",
+  "description": "${{ values.description }}",
+  "main": "dist/server.js",
+  "scripts": {
+    "start": "node dist/server.js",
+    "dev": "nodemon src/server.ts",
+    "build": "tsc",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write ."
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "helmet": "^7.1.0",
+    "winston": "^3.13.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.7",
+    "@typescript-eslint/eslint-plugin": "^7.7.0",
+    "@typescript-eslint/parser": "^7.7.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "nodemon": "^3.1.0",
+    "prettier": "^3.2.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/skeleton/src/app.ts
+++ b/skeleton/src/app.ts
@@ -1,0 +1,26 @@
+import express, { Express, Request, Response, NextFunction } from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import routes from './routes';
+import logger from './utils/logger';
+
+const app: Express = express();
+
+// Global Middleware
+app.use(helmet());
+app.use(cors());
+app.use(express.json());
+
+// Routes
+app.use('/api/v1', routes);
+
+// Global Error Handler
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+  logger.error(err.message);
+  res.status(500).json({
+    status: 'error',
+    message: 'Internal Server Error',
+  });
+});
+
+export default app;

--- a/skeleton/src/config/env.ts
+++ b/skeleton/src/config/env.ts
@@ -1,0 +1,26 @@
+import dotenv from 'dotenv';
+import { z } from 'zod';
+import logger from '../utils/logger';
+
+dotenv.config();
+
+const envSchema = z.object({
+  PORT: z.string().default('3000').transform((val) => parseInt(val, 10)),
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+  DATA_SOURCE: z.enum(['mock', 'postgres']).default('mock'),
+});
+
+const parseEnv = () => {
+  try {
+    return envSchema.parse(process.env);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      logger.error('Invalid environment variables:', error.format());
+    } else {
+      logger.error('Error parsing environment variables');
+    }
+    process.exit(1);
+  }
+};
+
+export const config = parseEnv();

--- a/skeleton/src/controllers/health.controller.ts
+++ b/skeleton/src/controllers/health.controller.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from 'express';
+
+export const getHealth = (req: Request, res: Response) => {
+  res.status(200).json({
+    status: 'UP',
+    timestamp: new Date().toISOString(),
+  });
+};

--- a/skeleton/src/controllers/student.controller.ts
+++ b/skeleton/src/controllers/student.controller.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+import { StudentRepositoryFactory } from '../factories/student.repository.factory';
+
+export const getStudents = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const repository = StudentRepositoryFactory.getRepository();
+    const students = await repository.getAll();
+    res.status(200).json(students);
+  } catch (error) {
+    console.error('Error fetching students:', error);
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+};

--- a/skeleton/src/data/students.json
+++ b/skeleton/src/data/students.json
@@ -1,0 +1,1 @@
+[{ "email": "john@example.com", "id": 1, "name": "John Doe" }, { "email": "jane@example.com", "id": 2, "name": "Jane Smith" }]

--- a/skeleton/src/factories/student.repository.factory.ts
+++ b/skeleton/src/factories/student.repository.factory.ts
@@ -1,0 +1,17 @@
+import { config } from '../config/env';
+import { IStudentRepository } from '../repositories/student.repository.interface';
+import { MockStudentRepository } from '../repositories/mock.student.repository';
+
+export class StudentRepositoryFactory {
+  static getRepository(): IStudentRepository {
+    switch (config.DATA_SOURCE) {
+      case 'mock':
+        return new MockStudentRepository();
+      // Future implementations:
+      // case 'postgres':
+      //   return new PostgresStudentRepository();
+      default:
+        throw new Error(`Unsupported data source: ${config.DATA_SOURCE}`);
+    }
+  }
+}

--- a/skeleton/src/repositories/mock.student.repository.ts
+++ b/skeleton/src/repositories/mock.student.repository.ts
@@ -1,0 +1,18 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+import { IStudentRepository } from './student.repository.interface';
+import { Student } from '../types/student';
+
+export class MockStudentRepository implements IStudentRepository {
+  private readonly dataPath = path.join(process.cwd(), 'src/data/students.json');
+
+  async getAll(): Promise<Student[]> {
+    try {
+      const data = await readFile(this.dataPath, 'utf-8');
+      return JSON.parse(data) as Student[];
+    } catch (error) {
+      console.error('Error reading mock data:', error);
+      return [];
+    }
+  }
+}

--- a/skeleton/src/repositories/student.repository.interface.ts
+++ b/skeleton/src/repositories/student.repository.interface.ts
@@ -1,0 +1,5 @@
+import { Student } from '../types/student';
+
+export interface IStudentRepository {
+  getAll(): Promise<Student[]>;
+}

--- a/skeleton/src/routes/index.ts
+++ b/skeleton/src/routes/index.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { getHealth } from '../controllers/health.controller';
+import studentRoutes from './student.routes';
+
+const router = Router();
+
+router.get('/health', getHealth);
+router.use('/students', studentRoutes);
+
+export default router;

--- a/skeleton/src/routes/student.routes.ts
+++ b/skeleton/src/routes/student.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getStudents } from '../controllers/student.controller';
+
+const router = Router();
+
+router.get('/', getStudents);
+
+export default router;

--- a/skeleton/src/server.ts
+++ b/skeleton/src/server.ts
@@ -1,0 +1,21 @@
+import app from './app';
+import { config } from './config/env';
+import logger from './utils/logger';
+import { Server } from 'http';
+
+const port = config.PORT;
+
+const server: Server = app.listen(port, () => {
+  logger.info(`Server is running on port ${port} in ${config.NODE_ENV} mode`);
+});
+
+const gracefulShutdown = () => {
+  logger.info('SIGTERM/SIGINT signal received: closing HTTP server');
+  server.close(() => {
+    logger.info('HTTP server closed');
+    process.exit(0);
+  });
+};
+
+process.on('SIGTERM', gracefulShutdown);
+process.on('SIGINT', gracefulShutdown);

--- a/skeleton/src/types/student.ts
+++ b/skeleton/src/types/student.ts
@@ -1,0 +1,5 @@
+export interface Student {
+  id: number;
+  name: string;
+  email: string;
+}

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,69 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: standard-service-template
+  title: Standard Service Template
+  description: Scaffolds a standard service based on the current repository structure.
+spec:
+  owner: platform-engineering
+  type: service
+
+  parameters:
+    - title: Service Details
+      required:
+        - name
+        - owner
+      properties:
+        name:
+          title: Name
+          type: string
+          description: Unique name of the component
+          ui:autofocus: true
+        owner:
+          title: Owner
+          type: string
+          description: Owner of the component
+          ui:field: OwnerPicker
+          ui:options:
+            allowedKinds:
+              - Group
+              - User
+        description:
+          title: Description
+          type: string
+          description: Brief description of the component
+
+  steps:
+    - id: fetch-base
+      name: Fetch Base
+      action: fetch:template
+      input:
+        url: ./skeleton
+        values:
+          name: ${{ parameters.name }}
+          owner: ${{ parameters.owner }}
+          description: ${{ parameters.description }}
+
+    - id: publish
+      name: Publish
+      action: publish:github
+      input:
+        allowedHosts: ['github.com']
+        description: This is ${{ parameters.name }}
+        repoUrl: ${{ parameters.repoUrl }}
+        repoVisibility: public
+
+    - id: register
+      name: Register
+      action: catalog:register-entity
+      input:
+        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        catalogInfoPath: '/catalog-info.yaml'
+
+  output:
+    links:
+      - title: Repository
+        url: ${{ steps.publish.output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps.register.output.entityRef }}


### PR DESCRIPTION
 Summary of changes:                                                                                                                                                     
- Moved existing source code and configuration files into the `skeleton/` directory.                                                                                    
 - Created root `template.yaml` for Backstage template definition.
 -  Created root `catalog-info.yaml` for template registration.                                                                                                           
 - Created `skeleton/catalog-info.yaml` for dynamic component registration.                                                                                              
 - Parameterized `skeleton/package.json` and `skeleton/catalog-info.yaml` with Nunjucks placeholders.                                                                    
 - Closes #7                                                                                                                                                               
